### PR TITLE
Update project setup (Support library 28.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changes
 
+* This version is based on support library 28.0.0.
 * This version is based on Kotlin 1.3.61.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Road signs changelog
 
+
+## NEXT
+
+* Not published yet
+
+### Changes
+
+* This version is based on Kotlin 1.3.61.
+
+
 ## [v.1.0.0](https://github.com/Umweltzone/roadsigns/releases/tag/v.1.0.0)
 
 * Published: 2019-08-30

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ build the sources directly from [this repository][github-roadsigns].
 
 ## License
 
-    Copyright 2019 Tobias Preuss
+    Copyright 2019-2020 Tobias Preuss
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/app/src/main/kotlin/info/metadude/kotlin/library/roadsigns/demo/DemoActivity.kt
+++ b/app/src/main/kotlin/info/metadude/kotlin/library/roadsigns/demo/DemoActivity.kt
@@ -33,7 +33,7 @@ class DemoActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener {
         roadSignView.type = item.roadSignType
     }
 
-    override fun onNothingSelected(parent: AdapterView<*>) {}
+    override fun onNothingSelected(parent: AdapterView<*>) = Unit
 
     private val String.roadSignType: RoadSign.Type
         get() {

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -3,9 +3,9 @@
 package info.metadude.kotlin.library.roadsigns
 
 object Android {
-    const val compileSdkVersion = 27
+    const val compileSdkVersion = 28
     const val minSdkVersion = 14
-    const val targetSdkVersion = 27
+    const val targetSdkVersion = 28
 }
 
 private const val kotlinVersion = "1.3.61"
@@ -32,7 +32,7 @@ object Libs {
         const val constraintLayout = "1.1.3"
         const val espresso = "3.0.2"
         const val rules = "1.0.2"
-        const val supportLibrary = "27.1.1"
+        const val supportLibrary = "28.0.0"
     }
 
     const val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -8,7 +8,7 @@ object Android {
     const val targetSdkVersion = 27
 }
 
-private const val kotlinVersion = "1.3.50"
+private const val kotlinVersion = "1.3.61"
 
 object Plugins {
 

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -16,7 +16,7 @@ object Plugins {
         const val android = "3.5.0"
         const val androidMavenPublish = "3.6.2"
         const val bintray = "1.8.4"
-        const val versions = "0.23.0"
+        const val versions = "0.27.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -13,7 +13,7 @@ private const val kotlinVersion = "1.3.50"
 object Plugins {
 
     private object Versions {
-        const val android = "3.5.0"
+        const val android = "3.5.3"
         const val androidMavenPublish = "3.6.2"
         const val bintray = "1.8.4"
         const val versions = "0.27.0"

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -14,7 +14,7 @@ object Plugins {
 
     private object Versions {
         const val android = "3.5.3"
-        const val androidMavenPublish = "3.6.2"
+        const val androidMavenPublish = "3.6.3"
         const val bintray = "1.8.4"
         const val versions = "0.27.0"
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,14 +1,12 @@
 apply plugin: "com.github.ben-manes.versions"
 
-dependencyUpdates.resolutionStrategy {
-    componentSelection { rules ->
-        rules.all { ComponentSelection selection ->
-            boolean rejected = ["alpha", "beta", "rc", "cr", "m", "preview", "b", "ea"].any { qualifier ->
-                selection.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
-            }
-            if (rejected) {
-                selection.reject("Release candidate")
-            }
-        }
+dependencyUpdates {
+    def isNonStable = { String version ->
+        def stableKeyword = ["RELEASE", "FINAL", "GA"].any { qualifier -> version.toUpperCase().contains(qualifier) }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+    rejectVersionIf {
+        isNonStable(it.candidate.version)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Noteworthy
- An update to Gradle wrapper v.6.x is avoided at this point in time. It causes the following error when using the library artifacts from an application project.
- Error: `roadsigns-x.x.x.aar: Resource and asset merger: The file name must end with .xml`