### PR TITLE
Migrate project to AndroidX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Road signs changelog
 
+## NEXT
+
+* Not published yet
+
+### Changes
+
+* This is the first version based on androidx.* libraries.
+* Use `androidx.annotation:annotation:1.1.0`.
+* Use `androidx.constraintlayout:constraintlayout:1.1.3`.
+* Use `androidx.vectordrawable:vectordrawable:1.1.0`.
+
 
 ## [v.2.0.0](https://github.com/Umweltzone/roadsigns/releases/tag/v.2.0.0)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         targetSdkVersion Android.targetSdkVersion
         versionCode Integer.valueOf(project.versionCode)
         versionName project.versionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -29,9 +29,10 @@ android {
 dependencies {
     implementation project(":roadsigns")
     implementation Libs.kotlinStdlib
-    implementation Libs.Support.appcompatV7
+    implementation Libs.Support.appCompat
     implementation Libs.Support.constraintLayout
 
     androidTestImplementation Libs.Support.Test.espresso
     androidTestImplementation Libs.Support.Test.rules
+    androidTestImplementation Libs.Support.Test.testExtJunit
 }

--- a/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityParameterizedTest.kt
+++ b/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityParameterizedTest.kt
@@ -1,14 +1,14 @@
 package info.metadude.kotlin.library.roadsigns.demo
 
 import android.content.Context
-import android.support.annotation.StringRes
-import android.support.test.InstrumentationRegistry
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions.click
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.*
-import android.support.test.rule.ActivityTestRule
 import android.view.View
+import androidx.annotation.StringRes
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
 import org.hamcrest.Matcher
 import org.junit.Before
 import org.junit.Rule
@@ -72,7 +72,7 @@ class DemoActivityParameterizedTest(
 
     @Before
     fun setUp() {
-        context = InstrumentationRegistry.getTargetContext()
+        context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityTest.kt
+++ b/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityTest.kt
@@ -1,13 +1,13 @@
 package info.metadude.kotlin.library.roadsigns.demo
 
 import android.content.Context
-import android.support.test.InstrumentationRegistry
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions.click
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.*
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Rule
@@ -26,7 +26,7 @@ class DemoActivityTest {
 
     @Before
     fun setUp() {
-        context = InstrumentationRegistry.getTargetContext()
+        context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/app/src/main/kotlin/info/metadude/kotlin/library/roadsigns/demo/DemoActivity.kt
+++ b/app/src/main/kotlin/info/metadude/kotlin/library/roadsigns/demo/DemoActivity.kt
@@ -1,11 +1,11 @@
 package info.metadude.kotlin.library.roadsigns.demo
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Spinner
+import androidx.appcompat.app.AppCompatActivity
 import info.metadude.kotlin.library.roadsigns.RoadSign
 
 class DemoActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener {

--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -38,4 +37,4 @@
             app:layout_constraintTop_toBottomOf="@+id/selectionView"
             app:layout_constraintBottom_toBottomOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -29,26 +29,29 @@ object Plugins {
 object Libs {
 
     private object Versions {
+        const val annotation = "1.1.0"
+        const val appCompat = "1.1.0"
         const val constraintLayout = "1.1.3"
-        const val espresso = "3.0.2"
-        const val rules = "1.0.2"
-        const val supportLibrary = "28.0.0"
+        const val espresso = "3.2.0"
+        const val rules = "1.2.0"
+        const val testExtJunit = "1.1.1"
+        const val vectorDrawable = "1.1.0"
     }
 
     const val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
     object Support {
 
-        const val annotations = "com.android.support:support-annotations:${Versions.supportLibrary}"
-        const val appcompatV7 = "com.android.support:appcompat-v7:${Versions.supportLibrary}"
-        const val constraintLayout = "com.android.support.constraint:constraint-layout:${Versions.constraintLayout}"
-        const val vectorDrawable = "com.android.support:support-vector-drawable:${Versions.supportLibrary}"
+        const val annotation = "androidx.annotation:annotation:${Versions.annotation}"
+        const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompat}"
+        const val constraintLayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
+        const val vectorDrawable = "androidx.vectordrawable:vectordrawable:${Versions.vectorDrawable}"
 
         object Test {
 
-            const val espresso = "com.android.support.test.espresso:espresso-core:${Versions.espresso}"
-            const val rules = "com.android.support.test:rules:${Versions.rules}"
-
+            const val espresso = "androidx.test.espresso:espresso-core:${Versions.espresso}"
+            const val rules = "androidx.test:rules:${Versions.rules}"
+            const val testExtJunit = "androidx.test.ext:junit:${Versions.testExtJunit}"
         }
 
     }

--- a/roadsigns/build.gradle
+++ b/roadsigns/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     implementation Libs.kotlinStdlib
-    implementation Libs.Support.annotations
+    implementation Libs.Support.annotation
     implementation Libs.Support.constraintLayout
     implementation Libs.Support.vectorDrawable
 }

--- a/roadsigns/src/main/kotlin/info/metadude/kotlin/library/roadsigns/RoadSign.kt
+++ b/roadsigns/src/main/kotlin/info/metadude/kotlin/library/roadsigns/RoadSign.kt
@@ -1,14 +1,14 @@
 package info.metadude.kotlin.library.roadsigns
 
 import android.content.Context
-import android.support.annotation.DrawableRes
-import android.support.annotation.StringRes
-import android.support.constraint.ConstraintLayout
-import android.support.graphics.drawable.VectorDrawableCompat
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 
 class RoadSign : ConstraintLayout {
 

--- a/roadsigns/src/main/res/layout/road_sign.xml
+++ b/roadsigns/src/main/res/layout/road_sign.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -18,4 +17,4 @@
             tools:ignore="ContentDescription"
             tools:srcCompat="@drawable/ic_environmental_badges_green"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* This is the first version based on `androidx.*` libraries.
* Use `androidx.annotation:annotation:1.1.0`.
* Use `androidx.constraintlayout:constraintlayout:1.1.3`.
* Use `androidx.vectordrawable:vectordrawable:1.1.0`.