### PR TITLE
Replace deprecated ActivityTestRule with ActivityScenarioRule.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,5 @@ dependencies {
     implementation Libs.Support.constraintLayout
 
     androidTestImplementation Libs.Support.Test.espresso
-    androidTestImplementation Libs.Support.Test.rules
     androidTestImplementation Libs.Support.Test.testExtJunit
 }

--- a/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityParameterizedTest.kt
+++ b/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityParameterizedTest.kt
@@ -8,8 +8,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.*
 import org.junit.Before
@@ -31,7 +31,8 @@ class DemoActivityParameterizedTest(
     @Suppress("RedundantVisibilityModifier")
     @Rule
     @JvmField
-    public val activityRule: ActivityTestRule<*> = ActivityTestRule(DemoActivity::class.java)
+    public val activityRule: ActivityScenarioRule<*> =
+        ActivityScenarioRule(DemoActivity::class.java)
 
     private lateinit var context: Context
 

--- a/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityTest.kt
+++ b/app/src/androidTest/java/info/metadude/kotlin/library/roadsigns/demo/DemoActivityTest.kt
@@ -5,22 +5,20 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class DemoActivityTest {
 
     @Suppress("RedundantVisibilityModifier")
     @Rule
     @JvmField
-    public val activityRule: ActivityTestRule<*> = ActivityTestRule(DemoActivity::class.java)
+    public val activityRule: ActivityScenarioRule<*> =
+        ActivityScenarioRule(DemoActivity::class.java)
 
     private lateinit var context: Context
 

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -33,7 +33,6 @@ object Libs {
         const val appCompat = "1.2.0"
         const val constraintLayout = "2.0.2"
         const val espresso = "3.3.0"
-        const val rules = "1.3.0"
         const val testExtJunit = "1.1.2"
         const val vectorDrawable = "1.1.0"
     }
@@ -50,7 +49,6 @@ object Libs {
         object Test {
 
             const val espresso = "androidx.test.espresso:espresso-core:${Versions.espresso}"
-            const val rules = "androidx.test:rules:${Versions.rules}"
             const val testExtJunit = "androidx.test.ext:junit:${Versions.testExtJunit}"
         }
 


### PR DESCRIPTION
# Description
+ Replace deprecated `androidx.test.rule.ActivityTestRule` with `androidx.test.ext.junit.rules.ActivityScenarioRule`.
+ Remove unneeded `androidx.test:rules`.
+ Remove unneeded AndroidJUnit4 test runner.

# Successfully executed `androidTest` with
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
