### PR TITLE
Fix Gradle 6 deployment resulting in build errors when using the aar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* Fix Gradle 6 deployment resulting in build errors when using the aar.
 * Add Danish translation. Thanks @larsnaesbye.
 * Add French translation. Thanks @Tititesouris.
 * Add Polish translation. Thanks @hexmind.

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ buildscript {
 
     dependencies {
         classpath Plugins.android
-        classpath Plugins.androidMavenPublish
-        classpath Plugins.bintray
         classpath Plugins.kotlin
         classpath Plugins.versions
     }

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -12,16 +12,11 @@ object Plugins {
 
     private object Versions {
         const val android = "4.1.0"
-        const val androidMavenPublish = "3.6.3"
-        const val bintray = "1.8.5"
         const val kotlin = "1.4.10"
         const val versions = "0.33.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"
-    const val androidMavenPublish =
-        "digital.wup:android-maven-publish:${Versions.androidMavenPublish}"
-    const val bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Versions.bintray}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val versions = "com.github.ben-manes:gradle-versions-plugin:${Versions.versions}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,11 +24,13 @@ versionVcsTag=v.3.1.0
 artifactId=roadsigns
 groupId=info.metadude.kotlin.library.roadsigns
 # Package information
-packageRepository=maven
 packageName=roadsigns
 packageDescription=A Kotlin library hosting a custom view for road signs.
 packageWebsiteUrl=https://github.com/Umweltzone/roadsigns
-packageIssueTrackingUrl=https://github.com/Umweltzone/roadsigns/issues
-packageVcsUrl=https://github.com/Umweltzone/roadsigns.git
-packageLicenses=['Apache-2.0']
-packageLabels=['kotlin', 'low emission zone', 'road signs', 'umweltzone', 'umweltplakette', 'diesel', 'fahrverbote']
+packageScmConnection=scm:git:git://github.com/Umweltzone/roadsigns.git
+packageScmDeveloperConnection=scm:git:ssh://github.com/Umweltzone/roadsigns.git
+packageLicenseApacheName=The Apache License, Version 2.0
+packageLicenseApacheUrl=https://github.com/Umweltzone/roadsigns/LICENSE.txt
+# Bintray
+bintrayPublicationName=Bintray
+bintrayUrl=https://api.bintray.com/maven/tbsprs/maven/roadsigns/;publish=0;override=1

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,32 +1,81 @@
-apply plugin: "digital.wup.android-maven-publish"
+// javadocJar and sourcesJar tasks pick up group and version
+group = project.groupId
+version = project.versionName
 
-publishing {
-    publications {
-        local(MavenPublication) {
-            from components.android
-            groupId project.groupId
-            artifactId project.artifactId
-            version = project.versionName
+Properties properties = new Properties()
+def propertiesFile = project.rootProject.file("${System.properties['user.home']}/.gradle/gradle.properties")
+if (propertiesFile.exists()) {
+    properties.load(propertiesFile.newDataInputStream())
+}
+def bintrayUser = properties.getProperty("bintrayUser") ?: System.getenv("BINTRAY_USER")
+def bintrayApiKey = properties.getProperty("bintrayApiKey") ?: System.getenv("BINTRAY_API_KEY")
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.versionName
+
+                artifact sourcesJar {
+                    classifier "sources"
+                }
+
+                artifact javadocJar {
+                    classifier "javadoc"
+                }
+
+                pom {
+                    name = project.packageName
+                    description = project.packageDescription
+                    url = project.packageWebsiteUrl
+                    licenses {
+                        license {
+                            name = project.packageLicenseApacheName
+                            url = project.packageLicenseApacheUrl
+                        }
+                    }
+                    scm {
+                        connection = project.packageScmConnection
+                        developerConnection = project.packageScmDeveloperConnection
+                        url = project.packageWebsiteUrl
+                    }
+                }
+
+                repositories {
+                    maven {
+                        name project.bintrayPublicationName
+                        url = uri(project.bintrayUrl)
+                        credentials {
+                            username = bintrayUser
+                            password = bintrayApiKey
+                        }
+                    }
+                }
+            }
         }
     }
 }
 
-apply plugin: "com.jfrog.bintray"
-
-group = project.groupId
-version = project.versionName
-
 task sourcesJar(type: Jar) {
+    group "publishing"
+    description "Generates source jar"
     archiveClassifier.set("sources")
     from android.sourceSets.main.java.srcDirs
 }
 
 task javadoc(type: Javadoc) {
+    group "publishing"
+    description "Generates javadoc"
     def paths = android.getBootClasspath()
     classpath += project.files(paths.join(File.pathSeparator))
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
+    group "publishing"
+    description "Generates javadocJar"
     archiveClassifier.set("javadoc")
     from javadoc.destinationDir
 }
@@ -37,69 +86,7 @@ javadoc {
     }
 }
 
-publishing {
-    publications {
-        bintray(MavenPublication) {
-            artifact "$buildDir/outputs/aar/${project.artifactId}-release.aar"
-            pom.withXml {
-                def dependenciesNode = asNode().appendNode("dependencies")
-
-                // Iterate over the implementation dependencies (we don"t want the test ones), adding a <dependency> node for each
-                configurations.implementation.allDependencies.each {
-                    // Ensure dependencies such as fileTree are not included in the pom.
-                    if (it.name != "unspecified") {
-                        def dependencyNode = dependenciesNode.appendNode("dependency")
-                        dependencyNode.appendNode("groupId", it.group)
-                        dependencyNode.appendNode("artifactId", it.name)
-                        dependencyNode.appendNode("version", it.version)
-                    }
-                }
-            }
-        }
-    }
-}
-
 artifacts {
     archives javadocJar
     archives sourcesJar
 }
-
-Properties properties = new Properties()
-def propertiesFile = project.rootProject.file("${System.properties['user.home']}/.gradle/gradle.properties")
-if (propertiesFile.exists()) {
-    properties.load(propertiesFile.newDataInputStream())
-}
-def bintrayUser = properties.getProperty("bintrayUser") ?: System.getenv("BINTRAY_USER")
-def bintrayApiKey = properties.getProperty("bintrayApiKey") ?: System.getenv("BINTRAY_API_KEY")
-
-bintray {
-    user = bintrayUser
-    key = bintrayApiKey
-    configurations = ["archives"]
-    publications = ["bintray"]
-    override = true
-    publish = true
-    dryRun = false
-
-    pkg {
-        repo = project.packageRepository
-        name = project.packageName
-        desc = project.packageDescription
-        websiteUrl = project.packageWebsiteUrl
-        issueTrackerUrl = project.packageIssueTrackingUrl
-        vcsUrl = project.packageVcsUrl
-        licenses = project.packageLicenses
-        labels = project.packageLabels
-
-        publicDownloadNumbers = true
-        version {
-            name = project.versionName
-            desc = project.versionDescription
-            released = new Date()
-            vcsTag = project.versionVcsTag
-        }
-    }
-}
-
-// Ensure the *.pom is generated before the artifacts are uploaded.
-bintrayUpload.dependsOn(generatePomFileForBintrayPublication)

--- a/roadsigns/build.gradle
+++ b/roadsigns/build.gradle
@@ -3,6 +3,7 @@ import info.metadude.kotlin.library.roadsigns.Libs
 
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
+apply plugin: "maven-publish"
 
 android {
     compileSdkVersion Android.compileSdkVersion


### PR DESCRIPTION
+ Error in Android application project:

  > A dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties) does not specify an aarFormatVersion value, which is a required value

+ Replace `digital.wup:android-maven-publish` with `maven-publish` plugin.
+ Replace `gradle-bintray-plugin` publication with `maven-publish` publication.
+ Omit sending Bintray specific attributes (`issue_tracker_url`, `vcs_url`, `labels`) every time when artifacts are published. These attributes have been manually set on the project at creation time.
+ Broken since d5d8d24fab772e486b222e6c747df203a02986b5.

# Successfully tested on
with Umweltzone app `release` build
  - :heavy_check_mark:  Google Pixel 2 device, Android 10 (API 29)
