### PR TITLE
Use Dokka to generate JavaDoc artifact.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 
     dependencies {
         classpath Plugins.android
+        classpath Plugins.dokka
         classpath Plugins.kotlin
         classpath Plugins.versions
     }

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/roadsigns/Dependencies.kt
@@ -12,11 +12,13 @@ object Plugins {
 
     private object Versions {
         const val android = "4.1.1"
+        const val dokka = "1.4.20"
         const val kotlin = "1.4.20"
         const val versions = "0.36.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"
+    const val dokka = "org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val versions = "com.github.ben-manes:gradle-versions-plugin:${Versions.versions}"
 }

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -66,23 +66,23 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-task javadoc(type: Javadoc) {
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     group "publishing"
-    description "Generates javadoc"
-    def paths = android.getBootClasspath()
-    classpath += project.files(paths.join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    group "publishing"
-    description "Generates javadocJar"
+    description "Generates javadocJar based on Dokka"
     archiveClassifier.set("javadoc")
-    from javadoc.destinationDir
+    from dokkaJavadoc.outputDirectory
 }
 
-javadoc {
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption("html5", true)
+dokkaJavadoc.configure {
+    moduleName.set("Roadsigns")
+    dokkaSourceSets {
+        named("main") {
+            sourceLink {
+                localDirectory.set(file("roadsigns/src/main/kotlin"))
+                remoteUrl.set(java.net.URL("https://github.com/Umweltzone/roadsigns/blob/master/roadsigns/src/main/kotlin"))
+                remoteLineSuffix.set("#L")
+            }
+        }
     }
 }
 

--- a/roadsigns/build.gradle
+++ b/roadsigns/build.gradle
@@ -4,6 +4,7 @@ import info.metadude.kotlin.library.roadsigns.Libs
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "maven-publish"
+apply plugin: "org.jetbrains.dokka"
 
 android {
     compileSdkVersion Android.compileSdkVersion


### PR DESCRIPTION
+ https://kotlin.github.io/dokka/
+ Before the _roadsigns-version-javadoc.jar_ was empty. This outputs an archive which actually contains the generated documentation.
+ Since this was broken since version 1.0.0 there are separate dokka-branches for each version respectively. These won't get merged.